### PR TITLE
resolve nested entities

### DIFF
--- a/apps/ods-api/schema.graphql
+++ b/apps/ods-api/schema.graphql
@@ -2,13 +2,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
-type QuestionGQL {
-  id: String!
-  prompt: String!
-  answers: [AnswerGQL!]!
-  surveys: [SurveyGQL!]!
-}
-
 type AnswerGQL {
   id: String!
   value: String!
@@ -31,6 +24,13 @@ enum OrgTier {
   GROUP
   SQUADRON
   OTHER
+}
+
+type QuestionGQL {
+  id: String!
+  prompt: String!
+  answers: [AnswerGQL!]!
+  surveys: [SurveyGQL!]!
 }
 
 type SurveyGQL {

--- a/apps/ods-api/schema.graphql
+++ b/apps/ods-api/schema.graphql
@@ -5,21 +5,25 @@
 type QuestionGQL {
   id: String!
   prompt: String!
+  answers: [AnswerGQL!]!
+  surveys: [SurveyGQL!]!
 }
 
 type AnswerGQL {
-  question: QuestionGQL
   id: String!
   value: String!
-  questionId: String!
-  surveyResponseId: String!
+  question: QuestionGQL!
+  surveyResponse: SurveyResponseGQL!
 }
 
 type OrgGQL {
   orgTier: OrgTier!
   id: String!
   name: String!
-  parentId: String
+  users: [UserGQL!]!
+  children: [OrgGQL!]!
+  parent: OrgGQL!
+  surveys: [SurveyGQL!]!
 }
 
 enum OrgTier {
@@ -31,16 +35,19 @@ enum OrgTier {
 
 type SurveyGQL {
   id: String!
+  orgs: [OrgGQL!]!
+  questions: [QuestionGQL!]!
+  surveyResponses: [SurveyResponseGQL!]!
 }
 
 type SurveyResponseGQL {
-  answers: [AnswerGQL!]
   id: String!
-  surveyId: String!
   openedDate: DateTime!
   closedDate: DateTime
   routeOutside: Boolean!
   resolution: String
+  answers: [AnswerGQL!]!
+  survey: SurveyGQL!
 }
 
 """
@@ -48,43 +55,24 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 """
 scalar DateTime
 
-input QuestionGQLInput {
+type UserGQL {
+  roles: Role!
   id: String!
-  prompt: String!
+  email: String!
+  enabled: Boolean!
 }
 
-input AnswerGQLInput {
-  question: QuestionGQLInput
-  id: String!
-  value: String!
-  questionId: String!
-  surveyResponseId: String!
-}
-
-input OrgGQLInput {
-  orgTier: OrgTier!
-  id: String!
-  name: String!
-  parentId: String
-}
-
-input SurveyGQLInput {
-  id: String!
-}
-
-input SurveyResponseGQLInput {
-  answers: [AnswerGQLInput!]
-  id: String!
-  surveyId: String!
-  openedDate: DateTime!
-  closedDate: DateTime
-  routeOutside: Boolean!
-  resolution: String
+enum Role {
+  ADMIN
+  DEI
+  EO
+  CC
 }
 
 type Query {
   findManySurveys: [SurveyGQL!]!
   findUniqueSurvey(surveyWhereUniqueInput: SurveyWhereUniqueInput!): SurveyGQL!
+  findManySurveyResponses: [SurveyResponseGQL!]!
   findUniqueSurveyResponse(surveyResponseWhereUniqueInput: SurveyResponseWhereUniqueInput!): SurveyResponseGQL!
   getIssuesByStatus(resolved: Boolean!): [String!]!
   getSurveyResponseData(surveyResponseWhereUniqueInput: SurveyResponseWhereUniqueInput!): SurveyResponseGQL!
@@ -153,7 +141,6 @@ input QuestionCreateNestedManyWithoutSurveysInput {
 
 input SurveyResponseCreateNestedManyWithoutSurveyInput {
   connect: SurveyResponseWhereUniqueInput
-  create: SurveyResponseGQLInput
 }
 
 input SurveyUpdateInput {
@@ -176,14 +163,8 @@ input SurveyCreateNestedOneWithoutSurveyResponsesInput {
 }
 
 input AnswerCreateNestedManyWithoutSurveyResponseInput {
-  connect: AnswerGQLInput
-  create: AnswerGQLInput
-}
-
-input SurveyResponseUpdateInput {
-  closedDate: DateTime
-  routeOutside: Boolean
-  resolution: String
+  connect: AnswerWhereUniqueInput
+  create: AnswerCreateInput
 }
 
 input AnswerCreateInput {
@@ -198,7 +179,12 @@ input QuestionCreateNestedOneWithoutAnswersInput {
 
 input SurveyResponseCreateNestedOneWithoutAnswersInput {
   connect: SurveyResponseWhereUniqueInput
-  create: SurveyResponseGQLInput
+}
+
+input SurveyResponseUpdateInput {
+  closedDate: DateTime
+  routeOutside: Boolean
+  resolution: String
 }
 
 input AnswerUpdateInput {
@@ -209,7 +195,7 @@ input AnswerUpdateInput {
 
 input OrgCreateInput {
   orgTier: OrgTier!
-  commanders: UserCreateNestedManyWithoutOrgsInput
+  users: UserCreateNestedManyWithoutOrgsInput
   parent: OrgCreateNestedOneWithoutChildrenInput
   children: OrgCreateNestedManyWithoutParentInput
   name: String!
@@ -234,7 +220,7 @@ input SurveyCreateNestedManyWithoutOrgsInput {
 
 input OrgUpdateInput {
   orgTier: OrgTier
-  commanders: UserCreateNestedManyWithoutOrgsInput
+  users: UserCreateNestedManyWithoutOrgsInput
   parent: OrgCreateNestedOneWithoutChildrenInput
   children: OrgCreateNestedManyWithoutParentInput
   name: String
@@ -243,7 +229,6 @@ input OrgUpdateInput {
 
 input QuestionCreateInput {
   surveys: SurveyCreateNestedManyWithoutQuestionsInput
-  id: String
   prompt: String!
 }
 
@@ -253,6 +238,5 @@ input SurveyCreateNestedManyWithoutQuestionsInput {
 
 input QuestionUpdateInput {
   surveys: SurveyCreateNestedManyWithoutQuestionsInput
-  id: String
   prompt: String
 }

--- a/apps/ods-api/schema.prisma
+++ b/apps/ods-api/schema.prisma
@@ -32,14 +32,14 @@ model RefreshToken {
 }
 
 model Org {
-  id         String   @id @default(uuid())
-  name       String   @unique // Example "552 ACNS"
-  orgTier    OrgTier
-  commanders User[]
-  parentId   String? // a parent org can have many child orgs
-  parent     Org?     @relation(name: "ParentChild", fields: [parentId], references: [id])
-  children   Org[]    @relation(name: "ParentChild") // This is a self relation
-  surveys    Survey[]
+  id       String   @id @default(uuid())
+  name     String   @unique // Example "552 ACNS"
+  orgTier  OrgTier
+  users    User[]
+  parentId String? // a parent org can have many child orgs
+  parent   Org?     @relation(name: "ParentChild", fields: [parentId], references: [id])
+  children Org[]    @relation(name: "ParentChild") // This is a self relation
+  surveys  Survey[]
 }
 
 model SurveyResponse {

--- a/apps/ods-api/src/answer/answer.resolver.ts
+++ b/apps/ods-api/src/answer/answer.resolver.ts
@@ -1,10 +1,19 @@
-import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
+import {
+  Resolver,
+  Mutation,
+  Args,
+  Query,
+  ResolveField,
+  Parent,
+} from '@nestjs/graphql';
 import { AnswerService } from './answer.service';
 import {
   AnswerGQL,
   AnswerCreateInput,
   AnswerUpdateInput,
   AnswerWhereUniqueInput,
+  QuestionGQL,
+  SurveyResponseGQL,
 } from '@odst/types/ods';
 //import { AccessTokenAuthGuard } from '../auth/guards/accessToken.authGuard';
 // import { UseGuards } from '@nestjs/common';
@@ -29,7 +38,9 @@ export class AnswerResolver {
 
   @Mutation(() => AnswerGQL, { name: 'createAnswer' })
   // @UseGuards(AccessTokenAuthGuard)
-  create(@Args('answerCreateInput') answerCreateInput: AnswerCreateInput) {
+  create(
+    @Args('answerCreateInput') answerCreateInput: AnswerCreateInput
+  ): Promise<AnswerGQL> {
     return this.answerService.create(answerCreateInput);
   }
 
@@ -51,5 +62,17 @@ export class AnswerResolver {
     answerWhereUniqueInput: AnswerWhereUniqueInput
   ): Promise<{ deleted: boolean }> {
     return this.answerService.delete(answerWhereUniqueInput);
+  }
+
+  @ResolveField(() => QuestionGQL)
+  async question(@Parent() answer: AnswerGQL): Promise<QuestionGQL | null> {
+    return this.answerService.question({ id: answer.id });
+  }
+
+  @ResolveField(() => SurveyResponseGQL)
+  async surveyResponse(
+    @Parent() answer: AnswerGQL
+  ): Promise<SurveyResponseGQL | null> {
+    return this.answerService.surveyResponse({ id: answer.id });
   }
 }

--- a/apps/ods-api/src/answer/answer.service.ts
+++ b/apps/ods-api/src/answer/answer.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Answer, Prisma } from '.prisma/ods/client';
+import { Answer, Prisma, Question, SurveyResponse } from '.prisma/ods/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -58,5 +58,21 @@ export class AnswerService {
     } catch (err) {
       return { deleted: false, message: err.message };
     }
+  }
+
+  async question(
+    answerWhereUniqueInput: Prisma.AnswerWhereUniqueInput
+  ): Promise<Question | null> {
+    return this.prisma.answer
+      .findUnique({ where: answerWhereUniqueInput })
+      .question();
+  }
+
+  async surveyResponse(
+    answerWhereUniqueInput: Prisma.AnswerWhereUniqueInput
+  ): Promise<SurveyResponse | null> {
+    return this.prisma.answer
+      .findUnique({ where: answerWhereUniqueInput })
+      .surveyResponse();
   }
 }

--- a/apps/ods-api/src/org/org.resolver.ts
+++ b/apps/ods-api/src/org/org.resolver.ts
@@ -1,10 +1,19 @@
-import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
+import {
+  Resolver,
+  Mutation,
+  Args,
+  Query,
+  ResolveField,
+  Parent,
+} from '@nestjs/graphql';
 import { OrgService } from './org.service';
 import {
   OrgGQL,
   OrgCreateInput,
   OrgUpdateInput,
   OrgWhereUniqueInput,
+  UserGQL,
+  SurveyGQL,
 } from '@odst/types/ods';
 //import { AccessTokenAuthGuard } from '../auth/guards/accessToken.authGuard';
 // import { UseGuards } from '@nestjs/common';
@@ -16,7 +25,6 @@ export class OrgResolver {
   @Query(() => [OrgGQL], { name: 'findManyOrgs' })
   // @UseGuards(AccessTokenAuthGuard)
   async findMany(): Promise<OrgGQL[]> {
-    // return this.orgService.findMany();
     return this.orgService.findMany({
       orderBy: {
         name: 'asc',
@@ -25,6 +33,7 @@ export class OrgResolver {
   }
 
   @Query(() => [OrgGQL], { name: 'getSubOrgs' })
+  //TODO redo with findMany
   // @UseGuards(AccessTokenAuthGuard)
   async getSubOrgs(
     @Args('orgWhereUniqueInput')
@@ -44,7 +53,9 @@ export class OrgResolver {
 
   @Mutation(() => OrgGQL, { name: 'createOrg' })
   // @UseGuards(AccessTokenAuthGuard)
-  create(@Args('orgCreateInput') orgCreateInput: OrgCreateInput) {
+  create(
+    @Args('orgCreateInput') orgCreateInput: OrgCreateInput
+  ): Promise<OrgGQL> {
     return this.orgService.create(orgCreateInput);
   }
 
@@ -66,5 +77,25 @@ export class OrgResolver {
     orgWhereUniqueInput: OrgWhereUniqueInput
   ): Promise<{ deleted: boolean }> {
     return this.orgService.delete(orgWhereUniqueInput);
+  }
+
+  @ResolveField(() => [UserGQL])
+  async users(@Parent() org: OrgGQL): Promise<UserGQL[]> {
+    return this.orgService.users({ id: org.id });
+  }
+
+  @ResolveField(() => [OrgGQL])
+  async children(@Parent() org: OrgGQL): Promise<OrgGQL[]> {
+    return this.orgService.children({ id: org.id });
+  }
+
+  @ResolveField(() => OrgGQL)
+  async parent(@Parent() org: OrgGQL): Promise<OrgGQL | null> {
+    return this.orgService.parent({ id: org.id });
+  }
+
+  @ResolveField(() => [SurveyGQL])
+  async surveys(@Parent() org: OrgGQL): Promise<SurveyGQL[]> {
+    return this.orgService.surveys({ id: org.id });
   }
 }

--- a/apps/ods-api/src/org/org.service.ts
+++ b/apps/ods-api/src/org/org.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Org, Prisma } from '.prisma/ods/client';
+import { Org, Prisma, User, Survey } from '.prisma/ods/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -74,9 +74,7 @@ export class OrgService {
     });
   }
 
-  async delete(
-    orgWhereUniqueInput: Prisma.OrgWhereUniqueInput
-  ): Promise<{ deleted: boolean; message?: string }> {
+  async delete(orgWhereUniqueInput: Prisma.OrgWhereUniqueInput) {
     try {
       await this.prisma.org.delete({
         where: orgWhereUniqueInput,
@@ -85,5 +83,31 @@ export class OrgService {
     } catch (err) {
       return { deleted: false, message: err.message };
     }
+  }
+
+  async users(
+    orgWhereUniqueInput: Prisma.OrgWhereUniqueInput
+  ): Promise<User[]> {
+    return this.prisma.org.findUnique({ where: orgWhereUniqueInput }).users();
+  }
+
+  async children(
+    orgWhereUniqueInput: Prisma.OrgWhereUniqueInput
+  ): Promise<Org[]> {
+    return this.prisma.org
+      .findUnique({ where: orgWhereUniqueInput })
+      .children();
+  }
+
+  async parent(
+    orgWhereUniqueInput: Prisma.OrgWhereUniqueInput
+  ): Promise<Org | null> {
+    return this.prisma.org.findUnique({ where: orgWhereUniqueInput }).parent();
+  }
+
+  async surveys(
+    orgWhereUniqueInput: Prisma.OrgWhereUniqueInput
+  ): Promise<Survey[]> {
+    return this.prisma.org.findUnique({ where: orgWhereUniqueInput }).surveys();
   }
 }

--- a/apps/ods-api/src/question/question.resolver.ts
+++ b/apps/ods-api/src/question/question.resolver.ts
@@ -1,4 +1,11 @@
-import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
+import {
+  Resolver,
+  Mutation,
+  Args,
+  Query,
+  Parent,
+  ResolveField,
+} from '@nestjs/graphql';
 import { QuestionService } from './question.service';
 import {
   QuestionGQL,
@@ -6,6 +13,8 @@ import {
   QuestionUpdateInput,
   QuestionWhereUniqueInput,
   SurveyWhereUniqueInput,
+  AnswerGQL,
+  SurveyGQL,
 } from '@odst/types/ods';
 //import { AccessTokenAuthGuard } from '../auth/guards/accessToken.authGuard';
 // import { UseGuards } from '@nestjs/common';
@@ -15,16 +24,17 @@ export class QuestionResolver {
   constructor(private readonly questionService: QuestionService) {}
 
   @Query(() => [QuestionGQL], { name: 'findManyQuestions' })
-  async findMany(): Promise<QuestionGQL[]> {
+  async findMany() {
     return this.questionService.findMany({});
   }
 
   @Query(() => [QuestionGQL], { name: 'getSubQuestions' })
   // @UseGuards(AccessTokenAuthGuard)
+  //TODO redo with findMany
   async getSubQuestions(
     @Args('surveyWhereUniqueInput')
     surveyWhereUniqueInput: SurveyWhereUniqueInput
-  ): Promise<QuestionGQL[]> {
+  ) {
     return this.questionService.findQuestionsInSurvey(surveyWhereUniqueInput);
   }
 
@@ -33,7 +43,7 @@ export class QuestionResolver {
   async findUnique(
     @Args('questionWhereUniqueInput')
     questionWhereUniqueInput: QuestionWhereUniqueInput
-  ): Promise<QuestionGQL | null> {
+  ) {
     return this.questionService.findUnique(questionWhereUniqueInput);
   }
 
@@ -52,19 +62,29 @@ export class QuestionResolver {
     questionWhereUniqueInput: QuestionWhereUniqueInput,
     @Args('QuestionUpdateInput')
     questionUpdateInput: QuestionUpdateInput
-  ): Promise<QuestionGQL> {
+  ) {
     return this.questionService.update(
       questionWhereUniqueInput,
       questionUpdateInput
     );
   }
-  
+
   @Mutation(() => QuestionGQL, { name: 'removeQuestion' })
   // @UseGuards(AccessTokenAuthGuard)
   async delete(
     @Args('questionWhereUniqueInput')
     questionWhereUniqueInput: QuestionWhereUniqueInput
-  ): Promise<{ deleted: boolean }> {
+  ) {
     return this.questionService.delete(questionWhereUniqueInput);
+  }
+
+  @ResolveField(() => [AnswerGQL])
+  async answers(@Parent() question: QuestionGQL): Promise<AnswerGQL[]> {
+    return this.questionService.answers({ id: question.id });
+  }
+
+  @ResolveField(() => [SurveyGQL])
+  async surveys(@Parent() question: QuestionGQL): Promise<SurveyGQL[]> {
+    return this.questionService.surveys({ id: question.id });
   }
 }

--- a/apps/ods-api/src/question/question.service.ts
+++ b/apps/ods-api/src/question/question.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Question, Prisma } from '.prisma/ods/client';
+import { Question, Prisma, Survey, Answer } from '.prisma/ods/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -71,5 +71,21 @@ export class QuestionService {
     } catch (err) {
       return { deleted: false, message: err.message };
     }
+  }
+
+  async answers(
+    questionWhereUniqueInput: Prisma.QuestionWhereUniqueInput
+  ): Promise<Answer[]> {
+    return this.prisma.question
+      .findUnique({ where: questionWhereUniqueInput })
+      .answers();
+  }
+
+  async surveys(
+    questionWhereUniqueInput: Prisma.QuestionWhereUniqueInput
+  ): Promise<Survey[]> {
+    return this.prisma.question
+      .findUnique({ where: questionWhereUniqueInput })
+      .surveys();
   }
 }

--- a/apps/ods-api/src/survey/survey.resolver.ts
+++ b/apps/ods-api/src/survey/survey.resolver.ts
@@ -64,7 +64,7 @@ export class SurveyResolver {
     return this.surveyService.delete(surveyWhereUniqueInput);
   }
 
-  @ResolveField(() => [OrgGQL], { name: 'orgs' })
+  @ResolveField(() => [OrgGQL])
   async orgs(@Parent() survey: SurveyGQL) {
     return this.surveyService.orgs({ id: survey.id });
   }

--- a/apps/ods-api/src/survey/survey.resolver.ts
+++ b/apps/ods-api/src/survey/survey.resolver.ts
@@ -1,10 +1,20 @@
-import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
+import {
+  Resolver,
+  Mutation,
+  Args,
+  Query,
+  Parent,
+  ResolveField,
+} from '@nestjs/graphql';
 import { SurveyService } from './survey.service';
 import {
   SurveyGQL,
   SurveyCreateInput,
   SurveyUpdateInput,
   SurveyWhereUniqueInput,
+  OrgGQL,
+  QuestionGQL,
+  SurveyResponseGQL,
 } from '@odst/types/ods';
 //import { AccessTokenAuthGuard } from '../auth/guards/accessToken.authGuard';
 // import { UseGuards } from '@nestjs/common';
@@ -15,8 +25,7 @@ export class SurveyResolver {
 
   @Query(() => [SurveyGQL], { name: 'findManySurveys' })
   // @UseGuards(AccessTokenAuthGuard)
-  async findMany(): Promise<SurveyGQL[]> {
-    // return this.surveyService.findMany();
+  async findMany() {
     return this.surveyService.findMany({});
   }
 
@@ -25,7 +34,7 @@ export class SurveyResolver {
   async findUnique(
     @Args('surveyWhereUniqueInput')
     surveyWhereUniqueInput: SurveyWhereUniqueInput
-  ): Promise<SurveyGQL | null> {
+  ) {
     return this.surveyService.findUnique(surveyWhereUniqueInput);
   }
 
@@ -42,7 +51,7 @@ export class SurveyResolver {
     surveyWhereUniqueInput: SurveyWhereUniqueInput,
     @Args('SurveyUpdateInput')
     surveyUpdateInput: SurveyUpdateInput
-  ): Promise<SurveyGQL> {
+  ) {
     return this.surveyService.update(surveyWhereUniqueInput, surveyUpdateInput);
   }
 
@@ -51,7 +60,24 @@ export class SurveyResolver {
   async delete(
     @Args('surveyWhereUniqueInput')
     surveyWhereUniqueInput: SurveyWhereUniqueInput
-  ): Promise<{ deleted: boolean }> {
+  ) {
     return this.surveyService.delete(surveyWhereUniqueInput);
+  }
+
+  @ResolveField(() => [OrgGQL], { name: 'orgs' })
+  async orgs(@Parent() survey: SurveyGQL) {
+    return this.surveyService.orgs({ id: survey.id });
+  }
+
+  @ResolveField(() => [QuestionGQL])
+  async questions(@Parent() survey: SurveyGQL): Promise<QuestionGQL[]> {
+    return this.surveyService.questions({ id: survey.id });
+  }
+
+  @ResolveField(() => [SurveyResponseGQL])
+  async surveyResponses(
+    @Parent() survey: SurveyGQL
+  ): Promise<SurveyResponseGQL[]> {
+    return this.surveyService.surveyResponses({ id: survey.id });
   }
 }

--- a/apps/ods-api/src/survey/survey.service.ts
+++ b/apps/ods-api/src/survey/survey.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { Survey, Prisma } from '.prisma/ods/client';
+import {
+  Survey,
+  Prisma,
+  SurveyResponse,
+  Question,
+  Org,
+} from '.prisma/ods/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -58,5 +64,29 @@ export class SurveyService {
     } catch (err) {
       return { deleted: false, message: err.message };
     }
+  }
+
+  async orgs(
+    surveyWhereUniqueInput: Prisma.SurveyWhereUniqueInput
+  ): Promise<Org[]> {
+    return this.prisma.survey
+      .findUnique({ where: surveyWhereUniqueInput })
+      .orgs();
+  }
+
+  async questions(
+    surveyWhereUniqueInput: Prisma.SurveyWhereUniqueInput
+  ): Promise<Question[]> {
+    return this.prisma.survey
+      .findUnique({ where: surveyWhereUniqueInput })
+      .questions();
+  }
+
+  async surveyResponses(
+    surveyWhereUniqueInput: Prisma.SurveyWhereUniqueInput
+  ): Promise<SurveyResponse[]> {
+    return this.prisma.survey
+      .findUnique({ where: surveyWhereUniqueInput })
+      .surveyResponses();
   }
 }

--- a/apps/ods-api/src/surveyResponse/surveyResponse.resolver.ts
+++ b/apps/ods-api/src/surveyResponse/surveyResponse.resolver.ts
@@ -44,7 +44,7 @@ export class SurveyResponseResolver {
 
   @Mutation(() => SurveyResponseGQL, { name: 'createSurveyResponse' })
   // @UseGuards(AccessTokenAuthGuard)
-  create(
+  async create(
     @Args('surveyResponseCreateInput')
     surveyResponseCreateInput: SurveyResponseCreateInput
   ): Promise<SurveyResponseGQL> {

--- a/apps/ods-api/src/surveyResponse/surveyResponse.resolver.ts
+++ b/apps/ods-api/src/surveyResponse/surveyResponse.resolver.ts
@@ -1,10 +1,19 @@
-import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
+import {
+  Resolver,
+  Mutation,
+  Args,
+  Query,
+  ResolveField,
+  Parent,
+} from '@nestjs/graphql';
 import { SurveyResponseService } from './surveyResponse.service';
 import {
   SurveyResponseGQL,
   SurveyResponseCreateInput,
   SurveyResponseUpdateInput,
   SurveyResponseWhereUniqueInput,
+  AnswerGQL,
+  SurveyGQL,
 } from '@odst/types/ods';
 
 // import { GetCurrentUserId } from '@odst/shared/nest';
@@ -15,12 +24,19 @@ import {
 export class SurveyResponseResolver {
   constructor(private readonly surveyResponseService: SurveyResponseService) {}
 
+  @Query(() => [SurveyResponseGQL], { name: 'findManySurveyResponses' })
+  // @UseGuards(AccessTokenAuthGuard)
+  async findMany(): Promise<SurveyResponseGQL[]> {
+    // return this.surveyResponseService.findMany();
+    return this.surveyResponseService.findMany({});
+  }
+
   @Query(() => SurveyResponseGQL, { name: 'findUniqueSurveyResponse' })
   // @UseGuards(AccessTokenAuthGuard)
   async findUnique(
     @Args('surveyResponseWhereUniqueInput')
     surveyResponseWhereUniqueInput: SurveyResponseWhereUniqueInput
-  ) {
+  ): Promise<SurveyResponseGQL | null> {
     return this.surveyResponseService.findUnique(
       surveyResponseWhereUniqueInput
     );
@@ -28,10 +44,10 @@ export class SurveyResponseResolver {
 
   @Mutation(() => SurveyResponseGQL, { name: 'createSurveyResponse' })
   // @UseGuards(AccessTokenAuthGuard)
-  async create(
+  create(
     @Args('surveyResponseCreateInput')
     surveyResponseCreateInput: SurveyResponseCreateInput
-  ) {
+  ): Promise<SurveyResponseGQL> {
     return this.surveyResponseService.create(surveyResponseCreateInput);
   }
 
@@ -42,7 +58,7 @@ export class SurveyResponseResolver {
     surveyResponseWhereUniqueInput: SurveyResponseWhereUniqueInput,
     @Args('SurveyResponseUpdateInput')
     surveyResponseUpdateInput: SurveyResponseUpdateInput
-  ) {
+  ): Promise<SurveyResponseGQL> {
     return this.surveyResponseService.update(
       surveyResponseWhereUniqueInput,
       surveyResponseUpdateInput
@@ -83,5 +99,17 @@ export class SurveyResponseResolver {
     );
   }
 
+  @ResolveField(() => [AnswerGQL])
+  async answers(
+    @Parent() surveyResponse: SurveyResponseGQL
+  ): Promise<AnswerGQL[]> {
+    return this.surveyResponseService.answers({ id: surveyResponse.id });
+  }
 
+  @ResolveField(() => SurveyGQL)
+  async survey(
+    @Parent() surveyResponse: SurveyResponseGQL
+  ): Promise<SurveyGQL | null> {
+    return this.surveyResponseService.survey({ id: surveyResponse.id });
+  }
 }

--- a/apps/ods-api/src/surveyResponse/surveyResponse.service.ts
+++ b/apps/ods-api/src/surveyResponse/surveyResponse.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { SurveyResponse, Prisma } from '.prisma/ods/client';
+import { SurveyResponse, Prisma, Survey, Answer } from '.prisma/ods/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -119,5 +119,21 @@ export class SurveyResponseService {
     } catch (err) {
       return { deleted: false, message: err.message };
     }
+  }
+
+  async survey(
+    AnswerWhereUniqueInput: Prisma.AnswerWhereUniqueInput
+  ): Promise<Survey | null> {
+    return this.prisma.surveyResponse
+      .findUnique({ where: AnswerWhereUniqueInput })
+      .survey();
+  }
+
+  async answers(
+    surveyResponseWhereUniqueInput: Prisma.SurveyResponseWhereUniqueInput
+  ): Promise<Answer[]> {
+    return this.prisma.surveyResponse
+      .findUnique({ where: surveyResponseWhereUniqueInput })
+      .answers();
   }
 }

--- a/apps/ods-api/src/user/user.module.ts
+++ b/apps/ods-api/src/user/user.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserService } from './user.service';
+import { UserResolver } from './user.resolver';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Module({
+  providers: [UserResolver, UserService, PrismaService],
+})
+export class UserModule {}

--- a/apps/ods-api/src/user/user.resolver.ts
+++ b/apps/ods-api/src/user/user.resolver.ts
@@ -1,0 +1,22 @@
+import { Resolver, Query, Parent, ResolveField } from '@nestjs/graphql';
+import { UserService } from './user.service';
+import { OrgGQL, UserGQL } from '@odst/types/ods';
+//import { AccessTokenAuthGuard } from '../auth/guards/accessToken.authGuard';
+// import { UseGuards } from '@nestjs/common';
+
+@Resolver(() => UserGQL)
+export class UserResolver {
+  constructor(private readonly userService: UserService) {}
+
+  // find all users
+  @Query(() => [UserGQL], { name: 'findManyUsers' })
+  // @UseGuards(AccessTokenAuthGuard)
+  async findMany() {
+    return this.userService.findMany({});
+  }
+
+  @ResolveField(() => [OrgGQL])
+  async orgs(@Parent() user: UserGQL) {
+    return await this.userService.orgs({ id: user.id });
+  }
+}

--- a/apps/ods-api/src/user/user.service.ts
+++ b/apps/ods-api/src/user/user.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { User, Prisma, Org } from '.prisma/ods/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class UserService {
+  constructor(private prisma: PrismaService) {}
+
+  async findMany(params: {
+    skip?: number;
+    take?: number;
+    cursor?: Prisma.UserWhereUniqueInput;
+    where?: Prisma.UserWhereInput;
+    orderBy?: Prisma.UserOrderByWithRelationInput;
+  }): Promise<User[]> {
+    const { skip, take, cursor, where, orderBy } = params;
+    return this.prisma.user.findMany({
+      skip,
+      take,
+      cursor,
+      where,
+      orderBy,
+    });
+  }
+
+  async orgs(
+    userWhereUniqueInput: Prisma.UserWhereUniqueInput
+  ): Promise<Org[]> {
+    return this.prisma.user.findUnique({ where: userWhereUniqueInput }).orgs();
+  }
+}

--- a/libs/types/ods/src/entity/answer.entity.ts
+++ b/libs/types/ods/src/entity/answer.entity.ts
@@ -1,6 +1,5 @@
-import { ObjectType, HideField, Field } from '@nestjs/graphql';
+import { ObjectType, HideField } from '@nestjs/graphql';
 import { Answer } from '.prisma/ods/client';
-import { QuestionGQL } from './question.entity';
 
 @ObjectType()
 export class AnswerGQL implements Answer {

--- a/libs/types/ods/src/entity/answer.entity.ts
+++ b/libs/types/ods/src/entity/answer.entity.ts
@@ -1,15 +1,15 @@
-import { ObjectType, InputType, Field } from '@nestjs/graphql';
+import { ObjectType, HideField, Field } from '@nestjs/graphql';
 import { Answer } from '.prisma/ods/client';
 import { QuestionGQL } from './question.entity';
 
 @ObjectType()
-@InputType('AnswerGQLInput')
 export class AnswerGQL implements Answer {
   id: string;
   value: string;
-  questionId: string;
-  surveyResponseId: string;
 
-  @Field(() => QuestionGQL, { nullable: true })
-  question?: QuestionGQL;
+  @HideField()
+  questionId: string;
+
+  @HideField()
+  surveyResponseId: string;
 }

--- a/libs/types/ods/src/entity/org.entity.ts
+++ b/libs/types/ods/src/entity/org.entity.ts
@@ -1,13 +1,14 @@
-import { ObjectType, Field, InputType } from '@nestjs/graphql';
+import { ObjectType, Field, HideField } from '@nestjs/graphql';
 import { Org, OrgTier } from '.prisma/ods/client';
 
 @ObjectType()
-@InputType('OrgGQLInput')
 export class OrgGQL implements Org {
   id: string;
   name: string;
 
   @Field(() => OrgTier)
   orgTier: OrgTier;
+
+  @HideField()
   parentId: string | null;
 }

--- a/libs/types/ods/src/entity/question.entity.ts
+++ b/libs/types/ods/src/entity/question.entity.ts
@@ -1,8 +1,7 @@
-import { ObjectType, InputType } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
 import { Question } from '.prisma/ods/client';
 
 @ObjectType()
-@InputType('QuestionGQLInput')
 export class QuestionGQL implements Question {
   id: string;
   prompt: string;

--- a/libs/types/ods/src/entity/survey.entity.ts
+++ b/libs/types/ods/src/entity/survey.entity.ts
@@ -1,8 +1,7 @@
-import { ObjectType, InputType } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
 import { Survey } from '.prisma/ods/client';
 
 @ObjectType()
-@InputType('SurveyGQLInput')
 export class SurveyGQL implements Survey {
   id: string;
 }

--- a/libs/types/ods/src/entity/surveyResponse.entity.ts
+++ b/libs/types/ods/src/entity/surveyResponse.entity.ts
@@ -1,17 +1,14 @@
-import { ObjectType, InputType, Field } from '@nestjs/graphql';
+import { ObjectType, HideField } from '@nestjs/graphql';
 import { SurveyResponse } from '.prisma/ods/client';
-import { AnswerGQL } from './answer.entity';
 
 @ObjectType()
-@InputType('SurveyResponseGQLInput')
 export class SurveyResponseGQL implements SurveyResponse {
   id: string;
+
+  @HideField()
   surveyId: string;
   openedDate: Date;
   closedDate: Date | null;
   routeOutside: boolean;
   resolution: string | null;
-
-  @Field(() => [AnswerGQL], { nullable: true })
-  answers: AnswerGQL[];
 }

--- a/libs/types/ods/src/entity/user.entity.ts
+++ b/libs/types/ods/src/entity/user.entity.ts
@@ -1,12 +1,13 @@
-import { ObjectType, InputType, HideField } from '@nestjs/graphql';
+import { ObjectType, Field, HideField } from '@nestjs/graphql';
 import { Role, User } from '.prisma/ods/client';
 
 @ObjectType()
-@InputType('UserGQLInput')
 export class UserGQL implements User {
   id: string;
   email: string;
   enabled: boolean;
+
+  @Field(() => Role)
   roles: Role;
 
   @HideField()

--- a/libs/types/ods/src/input/answer.create.input.ts
+++ b/libs/types/ods/src/input/answer.create.input.ts
@@ -3,7 +3,6 @@ import { Prisma } from '.prisma/ods/client';
 import { QuestionCreateNestedOneWithoutAnswersInput } from './question.create.input';
 import { SurveyResponseCreateNestedOneWithoutAnswersInput } from './surveyResponse.create.input';
 import { AnswerWhereUniqueInput } from './answer.unique.input';
-import { AnswerGQL } from '../entity/answer.entity';
 
 @InputType()
 export class AnswerCreateInput implements Prisma.AnswerCreateInput {
@@ -20,9 +19,9 @@ export class AnswerCreateInput implements Prisma.AnswerCreateInput {
 export class AnswerCreateNestedManyWithoutSurveyResponseInput
   implements Prisma.AnswerCreateNestedManyWithoutSurveyResponseInput
 {
-  @Field(() => AnswerGQL)
+  @Field(() => AnswerWhereUniqueInput)
   connect?: AnswerWhereUniqueInput;
-
-  @Field(() => AnswerGQL)
+  //TODO fix type, probably fixed on ODST-survey
+  @Field(() => AnswerCreateInput)
   create?: Prisma.AnswerCreateWithoutSurveyResponseInput;
 }

--- a/libs/types/ods/src/input/org.create.input.ts
+++ b/libs/types/ods/src/input/org.create.input.ts
@@ -17,7 +17,7 @@ export class OrgCreateWithoutSurveysInput
   orgTier: OrgTier;
 
   @Field(() => UserCreateNestedManyWithoutOrgsInput)
-  commanders?: Prisma.UserCreateNestedManyWithoutOrgsInput;
+  users?: Prisma.UserCreateNestedManyWithoutOrgsInput;
 
   @Field(() => OrgCreateNestedOneWithoutChildrenInput)
   parent?: Prisma.OrgCreateNestedOneWithoutChildrenInput;

--- a/libs/types/ods/src/input/question.create.input.ts
+++ b/libs/types/ods/src/input/question.create.input.ts
@@ -5,7 +5,6 @@ import { SurveyCreateNestedManyWithoutQuestionsInput } from './survey.create.inp
 
 @InputType()
 export class QuestionCreateInput implements Prisma.QuestionCreateInput {
-  id?: string;
   prompt: string;
 
   @Field(() => SurveyCreateNestedManyWithoutQuestionsInput)

--- a/libs/types/ods/src/input/surveyResponse.create.input.ts
+++ b/libs/types/ods/src/input/surveyResponse.create.input.ts
@@ -28,8 +28,9 @@ export class SurveyResponseCreateNestedManyWithoutSurveyInput
   @Field(() => SurveyResponseWhereUniqueInput)
   connect?: Prisma.SurveyResponseWhereUniqueInput;
 
-  @Field(() => SurveyResponseGQL)
-  create?: Prisma.SurveyResponseCreateWithoutSurveyInput;
+  //TODO fix type
+  // @Field(() => SurveyResponseGQL)
+  // create?: Prisma.SurveyResponseCreateWithoutSurveyInput;
 }
 
 @InputType()
@@ -39,6 +40,7 @@ export class SurveyResponseCreateNestedOneWithoutAnswersInput
   @Field(() => SurveyResponseWhereUniqueInput)
   connect?: Prisma.SurveyResponseWhereUniqueInput;
 
-  @Field(() => SurveyResponseGQL)
-  create?: Prisma.SurveyResponseCreateWithoutAnswersInput;
+  //TODO fix type
+  // @Field(() => SurveyResponseGQL)
+  // create?: Prisma.SurveyResponseCreateWithoutAnswersInput;
 }

--- a/libs/types/ods/src/input/surveyResponse.update.input.ts
+++ b/libs/types/ods/src/input/surveyResponse.update.input.ts
@@ -9,6 +9,7 @@ export class SurveyResponseUpdateInput
 
   // If this is included in update, make sure not anyone can change it,
   // so a CC can't come in and route something to themself that they shouldn't be seen
+  //TODO Org Guard
   routeOutside?: boolean;
   resolution?: string;
 }

--- a/package.json
+++ b/package.json
@@ -102,6 +102,8 @@
     "typescript": "4.6.2"
   },
   "resolutions": {
-    "@graphql-codegen/cli/**/ansi-regex": "^5.0.1"
+    "@graphql-codegen/cli/**/ansi-regex": "^5.0.1",
+    "@nrwl/angular/**/async": "^3.2.2",
+    "@angular-devkit/build-angular/**/async": "^3.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3970,19 +3970,7 @@ async-retry@^1.2.1:
   dependencies:
     retry "0.13.1"
 
-async@0.9.x:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
-  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
-
-async@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
-  dependencies:
-    lodash "^4.17.14"
-
-async@^3.2.0:
+async@0.9.x, async@^2.6.2, async@^3.2.0, async@^3.2.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
   integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
@@ -8572,7 +8560,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.17.21, lodash@^4.17.14, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0, lodash@~4.17.0:
+lodash@4.17.21, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0, lodash@~4.17.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
You can resolve nested entities via the graphql api.

For example

```typescript
findManySurveys {
    id
    orgs {
      id
    }
  }
```

this gets all id's for orgs attach to a survey (and shows which survey they're attached too).

Optimized for service -> database queries. see [prisma fluent api](https://www.prisma.io/docs/guides/performance-and-optimization/query-optimization-performance#do-i-have-to-use-the-fluent-api-to-enable-batching-of-queries) for details

e2e pass