### PR TITLE
case insensitive username/email

### DIFF
--- a/libs/auth/src/auth/auth.service.ts
+++ b/libs/auth/src/auth/auth.service.ts
@@ -144,9 +144,11 @@ export class AuthService {
     return token;
   }
 
+  //TODO when creating users, ensure that check if username/email exists is case insensitive
   async getUserByEmailOrUsername(
     emailOrUsername: string
   ): Promise<User | null> {
+    emailOrUsername = emailOrUsername.toLowerCase();
     //Gets user by email or username
     //could optmize to not make two db calls
 


### PR DESCRIPTION
Probably should move user creation business logic to auth lib and leave only the basic prisma.user.create() in the app libraries

Write the username how the user types it, but any time we read it, tolower() it to prevent case sensitive conflicts - including when we do the check if that username or email is taken by an existing user.